### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     expect \
     && rm -rf /var/lib/apt/lists/*
 
-ENV HYPHANET_VERSION=1501
+ARG HYPHANET_VERSION=1501
 ENV HYPHANET_INSTALLER_URL=https://www.draketo.de/dateien/freenet/build0${HYPHANET_VERSION}/new_installer_offline_${HYPHANET_VERSION}.jar
 ENV INSTALLER_JAR=new_installer_offline.jar
 ENV HYPHANET_HOME=/opt/hyphanet


### PR DESCRIPTION
This update allows you to set the version number during a manual build.
For example:
```docker build -t hyphanet --build-arg HYPHANET_VERSION=1503 https://github.com/PoulLorca/hyphanet-docker.git#main```

Please note that the image available at poullorca/hyphanet-node:v0.15.03 does not correspond to Hyphanet version 1503.